### PR TITLE
Modify Catalyst adapter to take three arrays of non-uniform grids and the data extents explicitly

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,16 +13,19 @@ jobs:
       run: |
         sudo apt-get update; sudo apt-get install gfortran libopenmpi-dev libfftw3-dev
         #
+        NVVERSION_A=20.11
+        NVVERSION_B=2011
+        CUDA_VERSION=11.1
         export NVHPC_SILENT=true
         export NVHPC_INSTALL_TYPE=single
         export NVHPC_INSTALL_DIR=$HOME/software/nvidia/hpc_sdk
-        wget https://developer.download.nvidia.com/hpc-sdk/nvhpc_2020_207_Linux_x86_64_cuda_11.0.tar.gz
-        tar xpzf nvhpc_2020_207_Linux_x86_64_cuda_11.0.tar.gz
-        ./nvhpc_2020_207_Linux_x86_64_cuda_11.0/install
-        rm -rf nvhpc_2020_207_Linux_x86_64_cuda_11.0*
+        wget https://developer.download.nvidia.com/hpc-sdk/$NVVERSION_A/nvhpc_2020_${NVVERSION_B}_Linux_x86_64_cuda_$CUDA_VERSION.tar.gz
+        tar xpzf nvhpc_2020_${NVVERSION_B}_Linux_x86_64_cuda_$CUDA_VERSION.tar.gz
+        ./nvhpc_2020_${NVVERSION_B}_Linux_x86_64_cuda_$CUDA_VERSION/install
+        rm -rf nvhpc_2020_${NVVERSION_B}_Linux_x86_64_cuda_$CUDA_VERSION*
     - name: test compilation
       run: |
-        NVVERSION=20.7
+        NVVERSION=20.11
         NVHPC_INSTALL_DIR=$HOME/software/nvidia/hpc_sdk
         NVARCH=`uname -s`_`uname -m`; export NVARCH
         NVCOMPILERS=$NVHPC_INSTALL_DIR; export NVCOMPILERS

--- a/src/catalyst_adapter.cxx
+++ b/src/catalyst_adapter.cxx
@@ -34,40 +34,38 @@ struct GlobalVars {
   vtkStructuredGrid* FlowGrid;
 #endif
   float *xc, *yc, *zc, *xyzc;
-  int nx, ny, nz;
-  int procDims[2];
-  int procIdx[2];
+  int lo[3],hi[3],lo_g[3],hi_g[3];
 };
 
 GlobalVars globals;
 
 // Routine to build mesh in VTK
-void BuildFlowGrid(unsigned int nx, double lx, unsigned int ny, double ly, unsigned int nz, double *zc)
+void BuildFlowGrid(int* lo, int* hi, double* xc, double* yc, double* zc)
 {
-
-  double dx = lx / nx;
-  double dy = ly / ny;
-
+int n[3];
+for (int i = 0; i < 3; i++) {
+   n[i] = hi[i] - lo[i] + 1;
+   }
 #if 0
   // Using managed memory here to avoid some memory movement in Paraview/Catalyst. Not strictly required.
-  cudaMallocManaged(&globals.xc, (nx + 2) * sizeof(float));
-  cudaMallocManaged(&globals.yc, (ny + 2) * sizeof(float));
-  cudaMallocManaged(&globals.zc, nz*sizeof(float));
+  cudaMallocManaged(&globals.xc, (n[0] + 2) * sizeof(float));
+  cudaMallocManaged(&globals.yc, (n[1] + 2) * sizeof(float));
+  cudaMallocManaged(&globals.zc, (n[2] + 2) * sizeof(float));
 
   // Set point coordinates (offset by -1 in i,j for ghosts)
-  for (int i = 0; i < nx + 2; ++i) globals.xc[i] = globals.procIdx[0] * lx + (i-1) * dx + dx / 2;
-  for (int j = 0; j < ny + 2; ++j) globals.yc[j] = globals.procIdx[1] * ly + (j-1) * dy + dy / 2;
-  for (int k = 0; k < nz; ++k) globals.zc[k] = zc[k];
+  for (int i = 0; i < n[0] + 2; ++i) globals.xc[i] = xc[k];
+  for (int j = 0; j < n[1] + 2; ++j) globals.yc[j] = yc[k];
+  for (int k = 0; k < n[2] + 2; ++k) globals.zc[k] = zc[k];
 #else
 
   // Using managed memory here to avoid some memory movement in Paraview/Catalyst. Not strictly required.
-  cudaMallocManaged(&globals.xyzc, (nx + 2) * (ny + 2) * nz * 3 * sizeof(float));
+  cudaMallocManaged(&globals.xyzc, (n[0] + 2) * (n[1] + 2) * (n[2] + 2) * 3 * sizeof(float));
   float* point = globals.xyzc;
-  for (int k = 0; k < nz; ++k) {
-    for (int j = 0; j < ny + 2; ++j) {
-      for (int i = 0; i < nx + 2; ++i) {
-        point[0] = globals.procIdx[0] * lx + (i-1) * dx + dx / 2;
-        point[1] = globals.procIdx[1] * ly + (j-1) * dy + dy / 2;
+  for (int k = 0; k < n[2] + 2; ++k) {
+    for (int j = 0; j < n[1] + 2; ++j) {
+      for (int i = 0; i < n[0] + 2; ++i) {
+        point[0] = xc[i];
+        point[1] = yc[j];
         point[2] = zc[k];
 	point += 3;
       }
@@ -75,7 +73,7 @@ void BuildFlowGrid(unsigned int nx, double lx, unsigned int ny, double ly, unsig
   }
   vtkNew<vtkFloatArray> pointArray;
   pointArray->SetNumberOfComponents(3);
-  pointArray->SetArray(globals.xyzc, static_cast<vtkIdType>((nx + 2) * (ny + 2) * nz * 3), 1);
+  pointArray->SetArray(globals.xyzc, static_cast<vtkIdType>((n[0] + 2) * (n[1] + 2) * (n[2] + 2) * 3), 1);
   vtkNew<vtkPoints> points;
   points->SetData(pointArray.GetPointer());
 #endif
@@ -85,9 +83,9 @@ void BuildFlowGrid(unsigned int nx, double lx, unsigned int ny, double ly, unsig
   xc->SetNumberOfComponents(1);
   yc->SetNumberOfComponents(1);
   zc->SetNumberOfComponents(1);
-  xc->SetArray(globals.xc, static_cast<vtkIdType>(nx + 2), 1);
-  yc->SetArray(globals.yc, static_cast<vtkIdType>(ny + 2), 1);
-  zc->SetArray(globals.zc, static_cast<vtkIdType>(nz), 1);
+  xc->SetArray(globals.xc, static_cast<vtkIdType>(n[0] + 2), 1);
+  yc->SetArray(globals.yc, static_cast<vtkIdType>(n[1] + 2), 1);
+  zc->SetArray(globals.zc, static_cast<vtkIdType>(n[2] + 2), 1);
 
   globals.FlowGrid->SetXCoordinates(xc.GetPointer());
   globals.FlowGrid->SetYCoordinates(yc.GetPointer());
@@ -96,9 +94,7 @@ void BuildFlowGrid(unsigned int nx, double lx, unsigned int ny, double ly, unsig
   globals.FlowGrid->SetPoints(points);
 #endif
 
-  globals.FlowGrid->SetExtent(globals.procIdx[0] * nx, (globals.procIdx[0] + 1) * nx + 1,
-		              globals.procIdx[1] * ny, (globals.procIdx[1] + 1) * ny + 1,
-			      0, nz - 1);
+  globals.FlowGrid->SetExtent(lo[0]-1,hi[0]+1,lo[1]-1,hi[1]+1,lo[2]-1,hi[2]+1);
 
 }
 
@@ -141,20 +137,17 @@ void InitializeFlowGridAttributes(unsigned int numberOfPoints,
 
 
 // Routine to build flow grid and associate velocity data arrays
-void InitializeFlowGrid(unsigned int nx, double lx, unsigned int ny, double ly, unsigned int nz, double* zc,
-                        double* uData, double* vData, double *wData, double* pData, double* qcritData,
-                        int* procDims, int* procIdx)
+void InitializeFlowGrid(int* lo, int* hi, int* lo_g, int* hi_g, double* xc, double* yc, double* zc,
+                        double* uData, double* vData, double *wData, double* pData, double* qcritData)
 {
-  unsigned int numberOfPoints = (nx + 2) * (ny + 2) * nz; //includes ghost points in x, y
+  unsigned int numberOfPoints = (hi[0]-lo[0]+1 + 2) * (hi[1]-lo[1]+1 + 2) * (hi[2]-lo[2]+1 + 2); //includes ghost points in x, y
 
-  for (int i = 0; i < 2; ++i) {
-    globals.procDims[i] = procDims[i];
-    globals.procIdx[i] = procIdx[i];
+  for (int i = 0; i < 3; ++i) {
+    globals.lo[i] = lo[i];
+    globals.hi[i] = hi[i];
+    globals.lo_g[i] = lo_g[i];
+    globals.hi_g[i] = hi_g[i];
   }
-
-  globals.nx = nx;
-  globals.ny = ny;
-  globals.nz = nz;
 
   std::cout << "Calling InitializeFlowGrid:" << std::endl;
   std::cout << "\tnumber of points (with ghost cells): " << numberOfPoints << std::endl;
@@ -164,7 +157,7 @@ void InitializeFlowGrid(unsigned int nx, double lx, unsigned int ny, double ly, 
 #else
   globals.FlowGrid = vtkStructuredGrid::New();
 #endif
-  BuildFlowGrid(nx, lx, ny, ly, nz, zc);
+  BuildFlowGrid(lo, hi, xc, yc, zc);
   InitializeFlowGridAttributes(numberOfPoints, uData, vData, wData, pData, qcritData);
 }
 
@@ -214,9 +207,9 @@ void CatalystCoProcess(double time, unsigned int timeStep)
   if (globals.Processor->RequestDataDescription(dataDescription.GetPointer()) != 0)
   {
     dataDescription->GetInputDescriptionByName("input")->SetGrid(globals.FlowGrid);
-    dataDescription->GetInputDescriptionByName("input")->SetWholeExtent(0, globals.procDims[0] * globals.nx + 1,
-		                                                        0, globals.procDims[1] * globals.ny + 1,
-			                                                0, globals.nz - 1);
+    dataDescription->GetInputDescriptionByName("input")->SetWholeExtent(globals.lo_g[0]-1, globals.hi_g[0] + 1,
+		                                                        globals.lo_g[1]-1, globals.hi_g[1] + 1,
+			                                                globals.lo_g[2]-1, globals.hi_g[2] + 1);
     globals.Processor->CoProcess(dataDescription.GetPointer());
   }
 }

--- a/src/catalyst_adapter.cxx
+++ b/src/catalyst_adapter.cxx
@@ -42,7 +42,7 @@ GlobalVars globals;
 // Routine to build mesh in VTK
 void BuildFlowGrid(int* lo, int* hi, double* xc, double* yc, double* zc)
 {
-int n[3];
+unsigned int n[3];
 for (int i = 0; i < 3; i++) {
    n[i] = hi[i] - lo[i] + 1;
    }

--- a/src/catalyst_interfaces.f90
+++ b/src/catalyst_interfaces.f90
@@ -1,19 +1,16 @@
 module catalyst_interfaces
   interface
-    subroutine InitializeFlowGrid(nx, lx, ny, ly, nz, zc, &
-                                  uData, vData, wData, pData, qcritData, &
-                                  procDims, procIdx) bind(C, name="InitializeFlowGrid")
+    subroutine InitializeFlowGrid(lo,hi,lo_g,hi_g,xc,yc,zc, &
+                                  uData, vData, wData, pData, qcritData) &
+                                  bind(C, name="InitializeFlowGrid")
       use iso_c_binding
-      integer(c_int), value :: nx, ny, nz
-      real(c_double), value :: lx, ly
-      real(c_double) ::  zc(*)
+      integer(c_int) ::  lo(*),hi(*),lo_g(*),hi_g(*)
+      real(c_double) ::  xc(*),yc(*),zc(*)
       real(c_double) ::  uData(*)
       real(c_double) ::  vData(*)
       real(c_double) ::  wData(*)
       real(c_double) ::  pData(*)
       real(c_double) ::  qcritData(*)
-      integer(c_int) ::  procDims(*)
-      integer(c_int) ::  procIdx(*)
     end subroutine InitializeFlowGrid
   end interface
 

--- a/src/catalyst_interfaces.f90
+++ b/src/catalyst_interfaces.f90
@@ -1,10 +1,10 @@
 module catalyst_interfaces
   interface
-    subroutine InitializeFlowGrid(lo,hi,lo_g,hi_g,xc,yc,zc, &
+    subroutine InitializeFlowGrid(n, ng, xc, yc, zc, &
                                   uData, vData, wData, pData, qcritData) &
                                   bind(C, name="InitializeFlowGrid")
       use iso_c_binding
-      integer(c_int) ::  lo(*),hi(*),lo_g(*),hi_g(*)
+      integer(c_int) ::  n(*),ng(*)
       real(c_double) ::  xc(*),yc(*),zc(*)
       real(c_double) ::  uData(*)
       real(c_double) ::  vData(*)

--- a/src/main.f90
+++ b/src/main.f90
@@ -113,7 +113,6 @@ program cans
   integer  :: irk,istep
   real(rp), allocatable, dimension(:) :: dzc,dzf,zc,zf,dzci,dzfi,dzflzi,dzclzi,zclzi
   real(rp), allocatable, dimension(:) :: xc,yc ! for catalyst
-  integer , dimension(3) :: lo,hi,lo_g,hi_g ! for catalyst
 #ifdef USE_CUDA
   integer :: istat
   integer(kind=cuda_count_kind) :: freeMem,totMem
@@ -320,14 +319,10 @@ program cans
   istat = cudaMemPrefetchAsync( dzf, size(dzf), cudaCpuDeviceId, 0 )
 #endif
   call initgrid(inivel,n(3),gr,lz,dzc,dzf,zc,zf)
-  lo(:) = [coord(1)*n(1)+1,coord(2)*n(2)+1,0*n(3)+1]
-  hi(:) = lo(:) + n(:) - 1
-  lo_g(:) = [1,1,1]
-  hi_g(:) = lo_g(:) + ng(:) - 1
-  do kk=lo(1)-1,hi(1)+1
+  do kk=0,n(1)+1
     xc(kk) = (kk-0.5)*dl(1)
   enddo
-  do kk=lo(2)-1,hi(2)+1
+  do kk=0,n(2)+1
     yc(kk) = (kk-0.5)*dl(2)
   enddo
 #ifdef USE_CUDA
@@ -436,8 +431,8 @@ program cans
   call boundp(cbcpre,n,bcpre,dl,dzc,dzf,qcr)
   catalyst_active = .TRUE.
   call CatalystInitialize(catalyst_active)
-  call InitializeFlowGrid(lo,hi,lo_g,hi_g,xc,yc,zc, &
-                          u(0,0,0), v(0,0,0), w(0,0,0), p(0,0,0), qcr(0,0,0))
+  call InitializeFlowGrid(n+[2,2,0],ng+[2,2,0],xc,yc,zc(1), &
+                          u(0,0,1), v(0,0,1), w(0,0,1), p(0,0,1), qcr(0,0,1))
   if (myid .eq. 0) print*, "Running Catalyst pipeline..."
   t0 = MPI_WTIME()
   call CatalystCoProcess(0.d0, 0)

--- a/src/main.f90
+++ b/src/main.f90
@@ -26,7 +26,7 @@ program cans
   use mod_bound      , only: boundp,bounduvw,updt_rhs_b,updthalo
   use mod_chkdiv     , only: chkdiv
   use mod_chkdt      , only: chkdt
-  use mod_common_mpi , only: myid,ierr
+  use mod_common_mpi , only: myid,ierr,coord
   use mod_correc     , only: correc
   use mod_debug      , only: chkmean
   use mod_fft        , only: fftini,fftend
@@ -112,12 +112,15 @@ program cans
   real(rp) :: dt,dti,dtmax,time,dtrk,dtrki,divtot,divmax
   integer  :: irk,istep
   real(rp), allocatable, dimension(:) :: dzc,dzf,zc,zf,dzci,dzfi,dzflzi,dzclzi,zclzi
+  real(rp), allocatable, dimension(:) :: xc,yc ! for catalyst
+  integer , dimension(3) :: lo,hi,lo_g,hi_g ! for catalyst
 #ifdef USE_CUDA
   integer :: istat
   integer(kind=cuda_count_kind) :: freeMem,totMem
   integer(8) :: totEle
   attributes(managed) :: dzc,dzf,zc,zf,dzci,dzfi,dzflzi,dzclzi,zclzi,lambdaxyp,ap,bp,cp,rhsbp
   attributes(managed) :: dudtrko,dvdtrko,dwdtrko,dudtrk,dvdtrk,dwdtrk,dudtrk_A,dvdtrk_A,dwdtrk_A,dudtrk_B,dvdtrk_B,dwdtrk_B
+  attributes(managed) :: xc,yc
 #endif
   real(rp) :: meanvel,meanvelu,meanvelv,meanvelw
   real(rp), dimension(3) :: dpdl
@@ -194,6 +197,7 @@ program cans
            dzclzi(0:n(3)+1), &
            dzflzi(0:n(3)+1), &
            zclzi( 0:n(3)+1))
+  allocate(xc(0:n(1)+1),yc(0:n(2)+1))
   allocate(rhsbp)
   allocate(rhsbp%x(n(2),n(3),0:1), &
            rhsbp%y(n(1),n(3),0:1), &
@@ -316,6 +320,16 @@ program cans
   istat = cudaMemPrefetchAsync( dzf, size(dzf), cudaCpuDeviceId, 0 )
 #endif
   call initgrid(inivel,n(3),gr,lz,dzc,dzf,zc,zf)
+  lo(:) = [coord(1)*n(1)+1,coord(2)*n(2)+1,0*n(3)+1]
+  hi(:) = lo(:) + n(:) - 1
+  lo_g(:) = [1,1,1]
+  hi_g(:) = lo_g(:) + ng(:) - 1
+  do kk=lo(1)-1,hi(1)+1
+    xc(kk) = (kk-0.5)*dl(1)
+  enddo
+  do kk=lo(2)-1,hi(2)+1
+    yc(kk) = (kk-0.5)*dl(2)
+  enddo
 #ifdef USE_CUDA
   istat = cudaMemPrefetchAsync(  zc, size( zc), mydev, 0 )
   istat = cudaMemPrefetchAsync(  zf, size( zf), mydev, 0 )
@@ -419,14 +433,11 @@ program cans
   include 'out2d.h90'
   include 'out3d.h90'
 #else
-  call updthalo((/n(1),n(2)/),1,qcr)
-  call updthalo((/n(1),n(2)/),2,qcr)
-
+  call boundp(cbcpre,n,bcpre,dl,dzc,dzf,qcr)
   catalyst_active = .TRUE.
   call CatalystInitialize(catalyst_active)
-  call InitializeFlowGrid(n(1), l(1)/dims(1), n(2), l(2)/dims(2), n(3), zc(1:n(3)), &
-                          u(0,0,1), v(0,0,1), w(0,0,1), p(0,0,1), qcr(0,0,1), &
-                          dims, (/ mod(myid, dims(1)), myid / dims(1) /))
+  call InitializeFlowGrid(lo,hi,lo_g,hi_g,xc,yc,zc, &
+                          u(0,0,0), v(0,0,0), w(0,0,0), p(0,0,0), qcr(0,0,0))
   if (myid .eq. 0) print*, "Running Catalyst pipeline..."
   t0 = MPI_WTIME()
   call CatalystCoProcess(0.d0, 0)
@@ -849,8 +860,7 @@ program cans
                          qcr(1:n(1),1:n(2),1:n(3)))
       include 'out3d.h90'
 #else
-      call updthalo((/n(1),n(2)/),1,qcr)
-      call updthalo((/n(1),n(2)/),2,qcr)
+      call boundp(cbcpre,n,bcpre,dl,dzc,dzf,qcr)
       if (myid .eq. 0) print*, "Running Catalyst pipeline..."
       t0 = MPI_WTIME()
       call CatalystCoProcess(time, istep)


### PR DESCRIPTION
This makes the interface work without modification for a code when pencils are aligned in another direction, or in the multi-block code with 3D parallelization and non-uniform grids in all directions, SNaC (I hope!).

I tested that my modifications do not compromise the performance, and the `.png` outputs look good.

@romerojosh can you have a quick look when you have time? Thanks!